### PR TITLE
Add Tailscale SSH and DNS support configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ ludus ansible role add -d ./ludus_tailscale
 tailscale_state: present/absent
 tailscale_authkey: "tskey-auth-<REDACTED_KEY>"
 tailscale_api_key: "tskey-api-<REDACTED_KEY>"
+tailscale_ssh: true/false
+tailscale_dns: true/flase
 ```
 ## Deploy role
 - set your config like the one in the example ludus-config.yaml

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -3,3 +3,5 @@
 tailscale_state: present
 tailscale_authkey: "tskey-auth-<REDACTED_KEY>"
 tailscale_api_key: "tskey-api-<REDACTED_KEY>"
+tailscale_ssh: false
+tailscale_dns: false

--- a/tasks/linux-install.yaml
+++ b/tasks/linux-install.yaml
@@ -40,7 +40,7 @@
       become: true
 
     - name: Connect to Tailscale network
-      ansible.builtin.command: tailscale up --authkey {{ tailscale_authkey }}
+      ansible.builtin.command: tailscale up --authkey {{ tailscale_authkey }}{{ ' --ssh' if tailscale_ssh | default(false) | bool else '' }}{{ ' --accept-dns=true' if tailscale_dns | default(false) | bool else ' --accept-dns=false' }}
       register: tailscale_up_result
       changed_when: tailscale_up_result.rc == 0
       failed_when: false

--- a/tasks/windows-install.yaml
+++ b/tasks/windows-install.yaml
@@ -25,16 +25,36 @@
         state: present
         arguments: /qn TS_INSTALLDIR="{{ program_files_dir }}\\Tailscale" TS_NOLAUNCH="true"
 
-    - name: Ensure Tailscale service is running
+    - name: Stop Tailscale service to ensure clean state
+      win_service:
+        name: Tailscale
+        state: stopped
+
+    - name: Start Tailscale service
       win_service:
         name: Tailscale
         state: started
         start_mode: auto
 
+    - name: Wait for Tailscale service to be ready
+      win_shell: |
+        $retries = 0
+        while ($retries -lt 10) {
+          try {
+            & '{{ program_files_dir }}\Tailscale\tailscale.exe' status | Out-Null
+            exit 0
+          } catch {
+            Start-Sleep -Seconds 2
+            $retries++
+          }
+        }
+        exit 1
+      register: tailscale_ready
+      failed_when: tailscale_ready.rc != 0
+      changed_when: false
+
     - name: Connect to Tailscale network
-      win_command: '"{{ program_files_dir }}\\Tailscale\\tailscale.exe" up --unattended --auth-key {{ tailscale_authkey }}'
-      args:
-        creates: '{{ ansible_env.ProgramData }}\\Tailscale\\tailscaled.state'
+      win_command: '"{{ program_files_dir }}\\Tailscale\\tailscale.exe" up --unattended --auth-key {{ tailscale_authkey }}{{ " --ssh" if tailscale_ssh | default(false) | bool else "" }}{{ " --accept-dns=true" if tailscale_dns | default(false) | bool else " --accept-dns=false" }}'
     - name: Check Tailscale connection status
       win_shell: |
         $status = & '{{ program_files_dir }}\Tailscale\tailscale.exe' status


### PR DESCRIPTION
Added role vars for enabling Tailsacle SSH and disabling Tailscale DNS. Default values are set to false.